### PR TITLE
HC-63 implement crud endpoints for Meals

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,10 @@
 			<artifactId>spring-dotenv</artifactId>
 			<version>4.0.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/nl/mpdev/hotel_california_backend/controllers/MealController.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/controllers/MealController.java
@@ -2,14 +2,17 @@ package nl.mpdev.hotel_california_backend.controllers;
 
 import nl.mpdev.hotel_california_backend.dtos.meals.MealCompleteResponseDto;
 import nl.mpdev.hotel_california_backend.mappers.meals.MealCompleteMapper;
+import nl.mpdev.hotel_california_backend.models.Meal;
 import nl.mpdev.hotel_california_backend.services.MealService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Controller
@@ -27,6 +30,12 @@ public class MealController {
 
   // GET
 
+  @GetMapping("/{id}")
+  public ResponseEntity<MealCompleteResponseDto> getMealById(@PathVariable Integer id) {
+    MealCompleteResponseDto mealCompleteResponseDto = mealCompleteMapper.toDto(mealService.getMealById(id));
+    return ResponseEntity.ok().body(mealCompleteResponseDto);
+  }
+
   @GetMapping("")
   public ResponseEntity<List<MealCompleteResponseDto>> getMeals() {
     List<MealCompleteResponseDto> meals = mealService.getMeals().stream().map(mealCompleteMapper::toDto).collect(Collectors.toList());
@@ -35,6 +44,7 @@ public class MealController {
   }
 
   // POST
+
 
 
   // PUT

--- a/src/main/java/nl/mpdev/hotel_california_backend/controllers/MealController.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/controllers/MealController.java
@@ -1,13 +1,38 @@
 package nl.mpdev.hotel_california_backend.controllers;
 
+import nl.mpdev.hotel_california_backend.dtos.meals.MealCompleteResponseDto;
+import nl.mpdev.hotel_california_backend.mappers.meals.MealCompleteMapper;
+import nl.mpdev.hotel_california_backend.services.MealService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Controller
+@RequestMapping("/api/v1/meals")
 public class MealController {
 
 
-  // Get
+  private final MealCompleteMapper mealCompleteMapper;
+  private final MealService mealService;
 
+  public MealController(MealCompleteMapper mealCompleteMapper, MealService mealService) {
+    this.mealCompleteMapper = mealCompleteMapper;
+    this.mealService = mealService;
+  }
+
+  // GET
+
+  @GetMapping("")
+  public ResponseEntity<List<MealCompleteResponseDto>> getMeals() {
+    List<MealCompleteResponseDto> meals = mealService.getMeals().stream().map(mealCompleteMapper::toDto).collect(Collectors.toList());
+    return ResponseEntity.ok().body(meals);
+
+  }
 
   // POST
 

--- a/src/main/java/nl/mpdev/hotel_california_backend/controllers/MealController.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/controllers/MealController.java
@@ -53,9 +53,13 @@ public class MealController {
     URI uri = URI.create(ServletUriComponentsBuilder.fromCurrentRequest().path("/" + responseDto.getId()).toUriString());
     return ResponseEntity.created(uri).body(responseDto);
   }
-
-
   // PUT
+
+  @PutMapping("/{id}")
+  public ResponseEntity<MealCompleteResponseDto> updateMeal(@PathVariable Integer id, @Valid @RequestBody MealCompleteRequestDto requestDto) {
+    Meal meal = mealService.updateMeal(id, mealCompleteMapper.toEntity(requestDto));
+    return ResponseEntity.ok().body(mealCompleteMapper.toDto(meal));
+  }
 
 
   // PATCH

--- a/src/main/java/nl/mpdev/hotel_california_backend/controllers/MealController.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/controllers/MealController.java
@@ -15,13 +15,11 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Controller
 @RequestMapping("/api/v1/meals")
 public class MealController {
-
 
   private final MealCompleteMapper mealCompleteMapper;
   private final MealService mealService;
@@ -59,18 +57,27 @@ public class MealController {
   // PUT
 
   @PutMapping("/{id}")
-  public ResponseEntity<MealCompleteResponseDto> updateMeal(@PathVariable Integer id, @Valid @RequestBody MealCompleteRequestDto requestDto) {
+  public ResponseEntity<MealCompleteResponseDto> updateMeal(@PathVariable Integer id,
+                                                            @Valid @RequestBody MealCompleteRequestDto requestDto) {
     Meal meal = mealService.updateMeal(id, mealCompleteMapper.toEntity(requestDto));
     return ResponseEntity.ok().body(mealCompleteMapper.toDto(meal));
   }
 
   // PATCH
 
-  // PATCH
   @PatchMapping("/{id}")
-  public ResponseEntity<MealCompleteResponseDto> updateMealFields(@PathVariable Integer id, @Valid @RequestBody MealCompleteRequestDto requestDto) {
+  public ResponseEntity<MealCompleteResponseDto> updateMealFields(@PathVariable Integer id,
+                                                                  @Valid @RequestBody MealCompleteRequestDto requestDto) {
 
     Meal meal = mealService.updateMealFields(id, mealCompleteMapper.toEntity(requestDto));
     return ResponseEntity.ok().body(mealCompleteMapper.toDto(meal));
+  }
+
+  // DELETE
+
+  @DeleteMapping("/{id}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void deleteMeal(@PathVariable Integer id) {
+    mealService.deleteMeal(id);
   }
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/controllers/MealController.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/controllers/MealController.java
@@ -1,0 +1,19 @@
+package nl.mpdev.hotel_california_backend.controllers;
+
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class MealController {
+
+
+  // Get
+
+
+  // POST
+
+
+  // PUT
+
+
+  // PATCH
+}

--- a/src/main/java/nl/mpdev/hotel_california_backend/controllers/MealController.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/controllers/MealController.java
@@ -1,5 +1,6 @@
 package nl.mpdev.hotel_california_backend.controllers;
 
+import jakarta.validation.Valid;
 import nl.mpdev.hotel_california_backend.dtos.meals.MealCompleteRequestDto;
 import nl.mpdev.hotel_california_backend.dtos.meals.MealCompleteResponseDto;
 import nl.mpdev.hotel_california_backend.mappers.meals.MealCompleteMapper;
@@ -46,7 +47,7 @@ public class MealController {
   // POST
 
   @PostMapping("")
-  public ResponseEntity<MealCompleteResponseDto> addMeal(@RequestBody MealCompleteRequestDto requestDto) {
+  public ResponseEntity<MealCompleteResponseDto> addMeal(@Valid @RequestBody MealCompleteRequestDto requestDto) {
     Meal meal = mealService.addMeal(mealCompleteMapper.toEntity(requestDto));
     MealCompleteResponseDto responseDto = mealCompleteMapper.toDto(meal);
     URI uri = URI.create(ServletUriComponentsBuilder.fromCurrentRequest().path("/" + responseDto.getId()).toUriString());

--- a/src/main/java/nl/mpdev/hotel_california_backend/controllers/MealController.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/controllers/MealController.java
@@ -1,5 +1,6 @@
 package nl.mpdev.hotel_california_backend.controllers;
 
+import nl.mpdev.hotel_california_backend.dtos.meals.MealCompleteRequestDto;
 import nl.mpdev.hotel_california_backend.dtos.meals.MealCompleteResponseDto;
 import nl.mpdev.hotel_california_backend.mappers.meals.MealCompleteMapper;
 import nl.mpdev.hotel_california_backend.models.Meal;
@@ -7,10 +8,10 @@ import nl.mpdev.hotel_california_backend.services.MealService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -32,19 +33,25 @@ public class MealController {
 
   @GetMapping("/{id}")
   public ResponseEntity<MealCompleteResponseDto> getMealById(@PathVariable Integer id) {
-    MealCompleteResponseDto mealCompleteResponseDto = mealCompleteMapper.toDto(mealService.getMealById(id));
-    return ResponseEntity.ok().body(mealCompleteResponseDto);
+    MealCompleteResponseDto responseDto = mealCompleteMapper.toDto(mealService.getMealById(id));
+    return ResponseEntity.ok().body(responseDto);
   }
 
   @GetMapping("")
   public ResponseEntity<List<MealCompleteResponseDto>> getMeals() {
     List<MealCompleteResponseDto> meals = mealService.getMeals().stream().map(mealCompleteMapper::toDto).collect(Collectors.toList());
     return ResponseEntity.ok().body(meals);
-
   }
 
   // POST
 
+  @PostMapping("")
+  public ResponseEntity<MealCompleteResponseDto> addMeal(@RequestBody MealCompleteRequestDto requestDto) {
+    Meal meal = mealService.addMeal(mealCompleteMapper.toEntity(requestDto));
+    MealCompleteResponseDto responseDto = mealCompleteMapper.toDto(meal);
+    URI uri = URI.create(ServletUriComponentsBuilder.fromCurrentRequest().path("/" + responseDto.getId()).toUriString());
+    return ResponseEntity.created(uri).body(responseDto);
+  }
 
 
   // PUT

--- a/src/main/java/nl/mpdev/hotel_california_backend/controllers/MealController.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/controllers/MealController.java
@@ -5,6 +5,7 @@ import nl.mpdev.hotel_california_backend.dtos.meals.MealCompleteRequestDto;
 import nl.mpdev.hotel_california_backend.dtos.meals.MealCompleteResponseDto;
 import nl.mpdev.hotel_california_backend.mappers.meals.MealCompleteMapper;
 import nl.mpdev.hotel_california_backend.models.Meal;
+import nl.mpdev.hotel_california_backend.repositories.MealRepository;
 import nl.mpdev.hotel_california_backend.services.MealService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,10 +25,12 @@ public class MealController {
 
   private final MealCompleteMapper mealCompleteMapper;
   private final MealService mealService;
+  private final MealRepository mealRepository;
 
-  public MealController(MealCompleteMapper mealCompleteMapper, MealService mealService) {
+  public MealController(MealCompleteMapper mealCompleteMapper, MealService mealService, MealRepository mealRepository) {
     this.mealCompleteMapper = mealCompleteMapper;
     this.mealService = mealService;
+    this.mealRepository = mealRepository;
   }
 
   // GET
@@ -61,6 +64,13 @@ public class MealController {
     return ResponseEntity.ok().body(mealCompleteMapper.toDto(meal));
   }
 
+  // PATCH
 
   // PATCH
+  @PatchMapping("/{id}")
+  public ResponseEntity<MealCompleteResponseDto> updateMealFields(@PathVariable Integer id, @Valid @RequestBody MealCompleteRequestDto requestDto) {
+
+    Meal meal = mealService.updateMealFields(id, mealCompleteMapper.toEntity(requestDto));
+    return ResponseEntity.ok().body(mealCompleteMapper.toDto(meal));
+  }
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/dtos/ingredients/IngredientCompleteRequestDto.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/dtos/ingredients/IngredientCompleteRequestDto.java
@@ -1,0 +1,11 @@
+package nl.mpdev.hotel_california_backend.dtos.ingredients;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class IngredientCompleteRequestDto {
+  private Integer id;
+  private String name;
+}

--- a/src/main/java/nl/mpdev/hotel_california_backend/dtos/ingredients/IngredientCompleteRequestDto.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/dtos/ingredients/IngredientCompleteRequestDto.java
@@ -8,4 +8,5 @@ import lombok.Getter;
 public class IngredientCompleteRequestDto {
   private Integer id;
   private String name;
+  private Integer mealId;
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/dtos/ingredients/IngredientCompleteResponseDto.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/dtos/ingredients/IngredientCompleteResponseDto.java
@@ -1,0 +1,11 @@
+package nl.mpdev.hotel_california_backend.dtos.ingredients;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class IngredientCompleteResponseDto {
+  private Integer id;
+  private String name;
+}

--- a/src/main/java/nl/mpdev/hotel_california_backend/dtos/ingredients/IngredientCompleteResponseDto.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/dtos/ingredients/IngredientCompleteResponseDto.java
@@ -8,5 +8,4 @@ import lombok.Getter;
 public class IngredientCompleteResponseDto {
   private Integer id;
   private String name;
-  private Integer mealId;
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/dtos/ingredients/IngredientCompleteResponseDto.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/dtos/ingredients/IngredientCompleteResponseDto.java
@@ -8,4 +8,5 @@ import lombok.Getter;
 public class IngredientCompleteResponseDto {
   private Integer id;
   private String name;
+  private Integer mealId;
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/dtos/meals/MealCompleteRequestDto.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/dtos/meals/MealCompleteRequestDto.java
@@ -1,4 +1,14 @@
 package nl.mpdev.hotel_california_backend.dtos.meals;
 
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
 public class MealCompleteRequestDto {
+  private Integer id;
+  private String name;
+  private String description;
+  private Double price;
+  private byte[] image;
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/dtos/meals/MealCompleteRequestDto.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/dtos/meals/MealCompleteRequestDto.java
@@ -1,0 +1,4 @@
+package nl.mpdev.hotel_california_backend.dtos.meals;
+
+public class MealCompleteRequestDto {
+}

--- a/src/main/java/nl/mpdev/hotel_california_backend/dtos/meals/MealCompleteRequestDto.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/dtos/meals/MealCompleteRequestDto.java
@@ -2,6 +2,10 @@ package nl.mpdev.hotel_california_backend.dtos.meals;
 
 import lombok.Builder;
 import lombok.Getter;
+import nl.mpdev.hotel_california_backend.dtos.ingredients.IngredientCompleteRequestDto;
+import nl.mpdev.hotel_california_backend.models.Ingredient;
+
+import java.util.List;
 
 @Builder
 @Getter
@@ -11,4 +15,5 @@ public class MealCompleteRequestDto {
   private String description;
   private Double price;
   private byte[] image;
+  private List<IngredientCompleteRequestDto> ingredients;
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/dtos/meals/MealCompleteResponseDto.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/dtos/meals/MealCompleteResponseDto.java
@@ -1,0 +1,4 @@
+package nl.mpdev.hotel_california_backend.dtos.meals;
+
+public class MealCompleteResponseDto {
+}

--- a/src/main/java/nl/mpdev/hotel_california_backend/dtos/meals/MealCompleteResponseDto.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/dtos/meals/MealCompleteResponseDto.java
@@ -1,12 +1,18 @@
 package nl.mpdev.hotel_california_backend.dtos.meals;
 
 import lombok.Builder;
+import lombok.Getter;
+import nl.mpdev.hotel_california_backend.dtos.ingredients.IngredientCompleteResponseDto;
+
+import java.util.List;
 
 @Builder
+@Getter
 public class MealCompleteResponseDto {
   private Integer id;
   private String name;
   private String description;
   private Double price;
   private byte[] image;
+  private List<IngredientCompleteResponseDto> ingredients;
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/dtos/meals/MealCompleteResponseDto.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/dtos/meals/MealCompleteResponseDto.java
@@ -1,4 +1,12 @@
 package nl.mpdev.hotel_california_backend.dtos.meals;
 
+import lombok.Builder;
+
+@Builder
 public class MealCompleteResponseDto {
+  private Integer id;
+  private String name;
+  private String description;
+  private Double price;
+  private byte[] image;
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/exceptions/GeneralException.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/exceptions/GeneralException.java
@@ -1,0 +1,7 @@
+package nl.mpdev.hotel_california_backend.exceptions;
+
+public class GeneralException extends RuntimeException {
+  public GeneralException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/nl/mpdev/hotel_california_backend/exceptions/RecordNotFoundException.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/exceptions/RecordNotFoundException.java
@@ -1,0 +1,11 @@
+package nl.mpdev.hotel_california_backend.exceptions;
+
+public class RecordNotFoundException extends RuntimeException{
+  public RecordNotFoundException() {
+    super("Record not found");
+  }
+
+  public RecordNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/nl/mpdev/hotel_california_backend/mappers/ingredients/IngredientCompleteMapper.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/mappers/ingredients/IngredientCompleteMapper.java
@@ -14,6 +14,7 @@ public class IngredientCompleteMapper {
     }
 
     return Ingredient.builder()
+      .id(dto.getId())
       .name(dto.getName())
       .build();
   }
@@ -22,7 +23,6 @@ public class IngredientCompleteMapper {
     return IngredientCompleteResponseDto.builder()
       .id(entity.getId())
       .name(entity.getName())
-      .mealId(entity.getMeal().getId())
       .build();
   }
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/mappers/ingredients/IngredientCompleteMapper.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/mappers/ingredients/IngredientCompleteMapper.java
@@ -3,6 +3,7 @@ package nl.mpdev.hotel_california_backend.mappers.ingredients;
 import nl.mpdev.hotel_california_backend.dtos.ingredients.IngredientCompleteRequestDto;
 import nl.mpdev.hotel_california_backend.dtos.ingredients.IngredientCompleteResponseDto;
 import nl.mpdev.hotel_california_backend.models.Ingredient;
+import nl.mpdev.hotel_california_backend.models.Meal;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -21,6 +22,7 @@ public class IngredientCompleteMapper {
     return IngredientCompleteResponseDto.builder()
       .id(entity.getId())
       .name(entity.getName())
+      .mealId(entity.getMeal().getId())
       .build();
   }
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/mappers/ingredients/IngredientCompleteMapper.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/mappers/ingredients/IngredientCompleteMapper.java
@@ -1,0 +1,26 @@
+package nl.mpdev.hotel_california_backend.mappers.ingredients;
+
+import nl.mpdev.hotel_california_backend.dtos.ingredients.IngredientCompleteRequestDto;
+import nl.mpdev.hotel_california_backend.dtos.ingredients.IngredientCompleteResponseDto;
+import nl.mpdev.hotel_california_backend.models.Ingredient;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IngredientCompleteMapper {
+  public Ingredient toEntity(IngredientCompleteRequestDto dto) {
+    if(dto == null) {
+      return null;
+    }
+
+    return Ingredient.builder()
+      .name(dto.getName())
+      .build();
+  }
+
+  public IngredientCompleteResponseDto toDto(Ingredient entity) {
+    return IngredientCompleteResponseDto.builder()
+      .id(entity.getId())
+      .name(entity.getName())
+      .build();
+  }
+}

--- a/src/main/java/nl/mpdev/hotel_california_backend/mappers/meals/MealCompleteMapper.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/mappers/meals/MealCompleteMapper.java
@@ -1,7 +1,36 @@
 package nl.mpdev.hotel_california_backend.mappers.meals;
 
+import nl.mpdev.hotel_california_backend.dtos.meals.MealCompleteRequestDto;
+import nl.mpdev.hotel_california_backend.dtos.meals.MealCompleteResponseDto;
+import nl.mpdev.hotel_california_backend.models.Meal;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MealCompleteMapper {
+
+  public Meal toEntity(MealCompleteRequestDto dto) {
+    if (dto == null) {
+      return null;
+    }
+
+    return Meal.builder()
+      .price(dto.getPrice())
+      .name(dto.getName())
+      .description(dto.getDescription())
+      .price(dto.getPrice())
+      .image(dto.getImage())
+      .build();
+  }
+
+
+  public MealCompleteResponseDto toDto(Meal entity) {
+    return MealCompleteResponseDto.builder()
+      .price(entity.getPrice())
+      .name(entity.getName())
+      .description(entity.getDescription())
+      .price(entity.getPrice())
+      .image(entity.getImage())
+      .build();
+  }
+
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/mappers/meals/MealCompleteMapper.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/mappers/meals/MealCompleteMapper.java
@@ -2,35 +2,44 @@ package nl.mpdev.hotel_california_backend.mappers.meals;
 
 import nl.mpdev.hotel_california_backend.dtos.meals.MealCompleteRequestDto;
 import nl.mpdev.hotel_california_backend.dtos.meals.MealCompleteResponseDto;
+import nl.mpdev.hotel_california_backend.mappers.ingredients.IngredientCompleteMapper;
 import nl.mpdev.hotel_california_backend.models.Meal;
 import org.springframework.stereotype.Component;
 
+import java.util.stream.Collectors;
+
 @Component
 public class MealCompleteMapper {
+
+  private final IngredientCompleteMapper ingredientCompleteMapper;
+
+  public MealCompleteMapper(IngredientCompleteMapper ingredientCompleteMapper) {
+    this.ingredientCompleteMapper = ingredientCompleteMapper;
+  }
 
   public Meal toEntity(MealCompleteRequestDto dto) {
     if (dto == null) {
       return null;
     }
-
     return Meal.builder()
       .price(dto.getPrice())
       .name(dto.getName())
       .description(dto.getDescription())
       .price(dto.getPrice())
       .image(dto.getImage())
+      .ingredients(dto.getIngredients().stream().map(ingredientCompleteMapper::toEntity).collect(Collectors.toList()))
       .build();
   }
 
-
   public MealCompleteResponseDto toDto(Meal entity) {
     return MealCompleteResponseDto.builder()
+      .id(entity.getId())
       .price(entity.getPrice())
       .name(entity.getName())
       .description(entity.getDescription())
       .price(entity.getPrice())
       .image(entity.getImage())
+      .ingredients(entity.getIngredients().stream().map(ingredientCompleteMapper::toDto).collect(Collectors.toList()))
       .build();
   }
-
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/mappers/meals/MealCompleteMapper.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/mappers/meals/MealCompleteMapper.java
@@ -1,0 +1,7 @@
+package nl.mpdev.hotel_california_backend.mappers.meals;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class MealCompleteMapper {
+}

--- a/src/main/java/nl/mpdev/hotel_california_backend/mappers/meals/MealCompleteMapper.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/mappers/meals/MealCompleteMapper.java
@@ -3,9 +3,11 @@ package nl.mpdev.hotel_california_backend.mappers.meals;
 import nl.mpdev.hotel_california_backend.dtos.meals.MealCompleteRequestDto;
 import nl.mpdev.hotel_california_backend.dtos.meals.MealCompleteResponseDto;
 import nl.mpdev.hotel_california_backend.mappers.ingredients.IngredientCompleteMapper;
+import nl.mpdev.hotel_california_backend.models.Ingredient;
 import nl.mpdev.hotel_california_backend.models.Meal;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Component
@@ -22,7 +24,6 @@ public class MealCompleteMapper {
       return null;
     }
     return Meal.builder()
-      .price(dto.getPrice())
       .name(dto.getName())
       .description(dto.getDescription())
       .price(dto.getPrice())

--- a/src/main/java/nl/mpdev/hotel_california_backend/models/Ingredient.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/models/Ingredient.java
@@ -3,7 +3,7 @@ package nl.mpdev.hotel_california_backend.models;
 import jakarta.persistence.*;
 import lombok.*;
 
-@Builder
+@Builder(toBuilder = true)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/nl/mpdev/hotel_california_backend/models/Ingredient.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/models/Ingredient.java
@@ -15,7 +15,7 @@ public class Ingredient {
   private Integer id;
   private String name;
 
-  @ManyToOne(fetch = FetchType.EAGER)
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "meal_id")
   private Meal meal;
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/models/Ingredient.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/models/Ingredient.java
@@ -1,9 +1,12 @@
 package nl.mpdev.hotel_california_backend.models;
 
 import jakarta.persistence.*;
-import lombok.Data;
+import lombok.*;
 
-@Data
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 @Table(name = "Ingredients")
 public class Ingredient {

--- a/src/main/java/nl/mpdev/hotel_california_backend/models/Meal.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/models/Meal.java
@@ -12,7 +12,6 @@ import java.util.List;
 @Entity
 @Table(name = "meals")
 
-//public class Meal extends MenuItem {
 public class Meal {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,17 +23,6 @@ public class Meal {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "order_id")
   private Order order;
-  @OneToMany(mappedBy = "meal")
+  @OneToMany(mappedBy = "meal", cascade = CascadeType.REMOVE , orphanRemoval = true)
   List<Ingredient> ingredients;
-
-
-//   public MealBuilder toBuilder() {
-//     return Meal.builder()
-//       .id(this.id)
-//       .name(this.name)
-//       .description(this.description)
-//       .price(this.price)
-//       .image(this.image)
-//       .ingredients(this.ingredients);
-//   }
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/models/Meal.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/models/Meal.java
@@ -21,7 +21,7 @@ public class Meal {
   private String description;
   private Double price;
   private byte[] image;
-  @ManyToOne(fetch = FetchType.EAGER)
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "order_id")
   private Order order;
   @OneToMany(mappedBy = "meal")

--- a/src/main/java/nl/mpdev/hotel_california_backend/models/Meal.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/models/Meal.java
@@ -1,20 +1,19 @@
 package nl.mpdev.hotel_california_backend.models;
 
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Data;
-import lombok.Getter;
+import lombok.*;
 
 import java.util.List;
 
-@Entity
-@Table(name = "meals")
 @Builder
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "meals")
 
 //public class Meal extends MenuItem {
 public class Meal {
-
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Integer id;
@@ -27,8 +26,4 @@ public class Meal {
   private Order order;
   @OneToMany(mappedBy = "meal")
   List<Ingredient> ingredients;
-
-  public Meal() {
-
-  }
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/models/Meal.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/models/Meal.java
@@ -1,13 +1,16 @@
 package nl.mpdev.hotel_california_backend.models;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
 
 import java.util.List;
 
 @Entity
-@Data
 @Table(name = "meals")
+@Builder
+@Getter
 
 //public class Meal extends MenuItem {
 public class Meal {
@@ -24,4 +27,8 @@ public class Meal {
   private Order order;
   @OneToMany(mappedBy = "meal")
   List<Ingredient> ingredients;
+
+  public Meal() {
+
+  }
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/models/Meal.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/models/Meal.java
@@ -5,7 +5,7 @@ import lombok.*;
 
 import java.util.List;
 
-@Builder
+@Builder(toBuilder = true)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -26,4 +26,15 @@ public class Meal {
   private Order order;
   @OneToMany(mappedBy = "meal")
   List<Ingredient> ingredients;
+
+
+//   public MealBuilder toBuilder() {
+//     return Meal.builder()
+//       .id(this.id)
+//       .name(this.name)
+//       .description(this.description)
+//       .price(this.price)
+//       .image(this.image)
+//       .ingredients(this.ingredients);
+//   }
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/repositories/IngredientRepository.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/repositories/IngredientRepository.java
@@ -1,0 +1,7 @@
+package nl.mpdev.hotel_california_backend.repositories;
+
+import nl.mpdev.hotel_california_backend.models.Ingredient;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IngredientRepository extends JpaRepository<Ingredient, Integer> {
+}

--- a/src/main/java/nl/mpdev/hotel_california_backend/repositories/IngredientRepository.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/repositories/IngredientRepository.java
@@ -3,5 +3,8 @@ package nl.mpdev.hotel_california_backend.repositories;
 import nl.mpdev.hotel_california_backend.models.Ingredient;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface IngredientRepository extends JpaRepository<Ingredient, Integer> {
+
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/repositories/MealRepository.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/repositories/MealRepository.java
@@ -1,0 +1,7 @@
+package nl.mpdev.hotel_california_backend.repositories;
+
+import nl.mpdev.hotel_california_backend.models.Meal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MealRepository extends JpaRepository<Meal, Integer> {
+}

--- a/src/main/java/nl/mpdev/hotel_california_backend/services/MealService.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/services/MealService.java
@@ -24,4 +24,8 @@ public class MealService {
   public Meal getMealById(Integer id) {
     return mealRepository.findById(id).orElseThrow(() -> new RuntimeException("Meal not found"));
   }
+
+  public Meal addMeal(Meal entity) {
+    return mealRepository.save(entity);
+  }
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/services/MealService.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/services/MealService.java
@@ -1,0 +1,7 @@
+package nl.mpdev.hotel_california_backend.services;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class MealService {
+}

--- a/src/main/java/nl/mpdev/hotel_california_backend/services/MealService.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/services/MealService.java
@@ -1,10 +1,12 @@
 package nl.mpdev.hotel_california_backend.services;
 
+import nl.mpdev.hotel_california_backend.dtos.meals.MealCompleteResponseDto;
 import nl.mpdev.hotel_california_backend.models.Meal;
 import nl.mpdev.hotel_california_backend.repositories.MealRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class MealService {
@@ -17,5 +19,9 @@ public class MealService {
 
   public List<Meal> getMeals() {
     return mealRepository.findAll();
+  }
+
+  public Meal getMealById(Integer id) {
+    return mealRepository.findById(id).orElseThrow(() -> new RuntimeException("Meal not found"));
   }
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/services/MealService.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/services/MealService.java
@@ -2,7 +2,9 @@ package nl.mpdev.hotel_california_backend.services;
 
 import nl.mpdev.hotel_california_backend.dtos.meals.MealCompleteResponseDto;
 import nl.mpdev.hotel_california_backend.exceptions.RecordNotFoundException;
+import nl.mpdev.hotel_california_backend.models.Ingredient;
 import nl.mpdev.hotel_california_backend.models.Meal;
+import nl.mpdev.hotel_california_backend.repositories.IngredientRepository;
 import nl.mpdev.hotel_california_backend.repositories.MealRepository;
 import org.springframework.stereotype.Service;
 
@@ -13,9 +15,11 @@ import java.util.Optional;
 public class MealService {
 
   private final MealRepository mealRepository;
+  private final IngredientRepository ingredientRepository;
 
-  public MealService(MealRepository mealRepository) {
+  public MealService(MealRepository mealRepository, IngredientRepository ingredientRepository) {
     this.mealRepository = mealRepository;
+    this.ingredientRepository = ingredientRepository;
   }
 
   public List<Meal> getMeals() {
@@ -27,18 +31,40 @@ public class MealService {
   }
 
   public Meal addMeal(Meal entity) {
-    return mealRepository.save(entity);
+    Meal savedMeal = mealRepository.save(entity);
+
+    List<Ingredient> savedIngredients = savedMeal.getIngredients().stream()
+      .map(ingredient -> Ingredient.builder()
+        .meal(savedMeal)
+        .name(ingredient.getName())
+        .build())
+      .map(ingredientRepository::save)
+      .toList();
+
+    return savedMeal.toBuilder()
+      .ingredients(savedIngredients)  // Set the updated ingredients list
+      .build();
   }
 
   public Meal updateMeal(Integer id, Meal entity) {
     Meal existingMeal = mealRepository.findById(id).orElseThrow(() -> new RecordNotFoundException());
+    List<Ingredient> savedIngredients = entity.getIngredients().stream()
+      .map(ingredient -> {
+        Ingredient existingIngredient = ingredientRepository.findById(ingredient.getId()).orElseThrow(() -> new RecordNotFoundException());
+        Ingredient updatedIngredient = Ingredient.builder()
+          .id(existingIngredient.getId())
+          .name(ingredient.getName())
+          .build();
+        return ingredientRepository.save(updatedIngredient);
+      }).toList();
+
     Meal updatedMeal = Meal.builder()
       .id(existingMeal.getId())
       .name(entity.getName())
       .description(entity.getDescription())
       .price(entity.getPrice())
       .image(entity.getImage())
-      .ingredients(entity.getIngredients())
+      .ingredients(savedIngredients)
       .build();
     return mealRepository.save(updatedMeal);
   }

--- a/src/main/java/nl/mpdev/hotel_california_backend/services/MealService.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/services/MealService.java
@@ -83,6 +83,11 @@ public class MealService {
   }
 
 
+  public void deleteMeal(Integer id) {
+    mealRepository.findById(id).orElseThrow(() -> new RecordNotFoundException());
+    mealRepository.deleteById(id);
+  }
+
 
   private void setFieldsIfNotNUll(Object existingObject, Object incomingObject) {
     Field[] fields = incomingObject.getClass().getDeclaredFields();
@@ -121,4 +126,6 @@ public class MealService {
       }
     }
   }
+
+
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/services/MealService.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/services/MealService.java
@@ -118,9 +118,6 @@ public class MealService {
           .name(incoming.getName())
           .build();
         ingredientRepository.save(existingIngredient);
-      } else {
-        // Optionally handle adding new ingredients if necessary
-        existingIngredients.add(incoming);
       }
     }
   }

--- a/src/main/java/nl/mpdev/hotel_california_backend/services/MealService.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/services/MealService.java
@@ -1,7 +1,21 @@
 package nl.mpdev.hotel_california_backend.services;
 
+import nl.mpdev.hotel_california_backend.models.Meal;
+import nl.mpdev.hotel_california_backend.repositories.MealRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class MealService {
+
+  private final MealRepository mealRepository;
+
+  public MealService(MealRepository mealRepository) {
+    this.mealRepository = mealRepository;
+  }
+
+  public List<Meal> getMeals() {
+    return mealRepository.findAll();
+  }
 }

--- a/src/main/java/nl/mpdev/hotel_california_backend/services/MealService.java
+++ b/src/main/java/nl/mpdev/hotel_california_backend/services/MealService.java
@@ -1,6 +1,7 @@
 package nl.mpdev.hotel_california_backend.services;
 
 import nl.mpdev.hotel_california_backend.dtos.meals.MealCompleteResponseDto;
+import nl.mpdev.hotel_california_backend.exceptions.RecordNotFoundException;
 import nl.mpdev.hotel_california_backend.models.Meal;
 import nl.mpdev.hotel_california_backend.repositories.MealRepository;
 import org.springframework.stereotype.Service;
@@ -22,10 +23,23 @@ public class MealService {
   }
 
   public Meal getMealById(Integer id) {
-    return mealRepository.findById(id).orElseThrow(() -> new RuntimeException("Meal not found"));
+    return mealRepository.findById(id).orElseThrow(() -> new RecordNotFoundException());
   }
 
   public Meal addMeal(Meal entity) {
     return mealRepository.save(entity);
+  }
+
+  public Meal updateMeal(Integer id, Meal entity) {
+    Meal existingMeal = mealRepository.findById(id).orElseThrow(() -> new RecordNotFoundException());
+    Meal updatedMeal = Meal.builder()
+      .id(existingMeal.getId())
+      .name(entity.getName())
+      .description(entity.getDescription())
+      .price(entity.getPrice())
+      .image(entity.getImage())
+      .ingredients(entity.getIngredients())
+      .build();
+    return mealRepository.save(updatedMeal);
   }
 }


### PR DESCRIPTION
Added all the endpoints for this table. I decided that this endpoints also will fill in all of its data of the relaiton it has with the Ingredients table.

Spend quite a bit of time refining the way I could solve the 2 insertion at once. A bit challening but it worked out.


- **Add base files**
- **Add builder pattern to dtos and entity and add this to the mapper to test it out**
- **Add get endpoint for all meals**
- **Add getMealById**
- **Add addMeal endpoint**
- **Add the Validation dependency already and @Valid annotation from now on**
- **Add updateMeal endpoint & add RecordNotFoundException**
- **Fix the Post request**
- **Add updateMeal endpoint**
- **Add updateMealFields endpoint**
- **Refactor the patch methods a bit**
- **Fix the cascase type & orphanremoval**
